### PR TITLE
keyboard navigation on by default

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -151,7 +151,7 @@ return {
         externalHostsFiles: [],
         externalRecipeFiles: [],
         iconBadgeEnabled: true,
-        keyboardNavigation: false,
+        keyboardNavigation: true,
         noTooltips: false,
         popupCollapseAllDomains: false,
         popupCollapseBlacklistedDomains: false,


### PR DESCRIPTION
I don't see any reason why not to enable keyboardNavigation by default. Someone using the mouse only does not get hurt. And if this doesn't make it upstream patchers would probably want this to come already enabled.